### PR TITLE
Remove a experimental caution for liquid

### DIFF
--- a/src/built-in.rst
+++ b/src/built-in.rst
@@ -62,7 +62,7 @@ In many cases, what you need to write is **in:**, **out**: and **formatter** sec
 Using variables
 ~~~~~~~~~~~~~~~~~~
 
-You can embed environment variables in configuration file using `Liquid template engine <http://liquidmarkup.org/>`_ (This is experimental feature. Behavior might change or be removed in future releases).
+You can embed environment variables in configuration file using `Liquid template engine <http://liquidmarkup.org/>`_.
 
 To use template engine, configuration file name must end with ``.yml.liquid``.
 


### PR DESCRIPTION
This document says (This is experimental feature. Behavior might change or be removed in future releases).
But, I think the feature has been used by many people. 
So, we can remove this caution?